### PR TITLE
Fix getbalance returning garbage values for non-existent accounts.

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -514,7 +514,7 @@ int64 GetAccountBalance(CWalletDB& walletdb, const string& strAccount, int nMinD
         if (!wtx.IsFinal())
             continue;
 
-        int64 nGenerated, nReceived, nSent, nFee;
+        int64 nGenerated = 0, nReceived, nSent, nFee;
         wtx.GetAccountAmounts(strAccount, nGenerated, nReceived, nSent, nFee);
 
         if (nReceived != 0 && wtx.GetDepthInMainChain() >= nMinDepth)


### PR DESCRIPTION
Fix getbalance returning garbage values for non-existent accounts due to nGenerated variable not being zero initialized.
