### PR TITLE
Removing double 'v' in the About dialog version

### DIFF
--- a/src/qt/forms/aboutdialog.ui
+++ b/src/qt/forms/aboutdialog.ui
@@ -68,7 +68,7 @@ QLabel { background: transparent; }</string>
           <string notr="true">QLabel { background: transparent; }</string>
          </property>
          <property name="text">
-          <string>&lt;b&gt;CryptoBullion&lt;/b&gt; v</string>
+          <string>&lt;b&gt;CryptoBullion&lt;/b&gt; </string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>


### PR DESCRIPTION
The wallet version is currently displaying with double 'v' for 'version'